### PR TITLE
Adds node splitting via typing '---' into editor

### DIFF
--- a/products/app/src/components/editor/Editor.vue
+++ b/products/app/src/components/editor/Editor.vue
@@ -3,7 +3,7 @@ import { type PropType, ref, watch, computed, nextTick } from 'vue'
 import { FocusTrap } from 'focus-trap-vue'
 import { useEditor, EditorContent } from '@tiptap/vue-3'
 import Scrollable from './Scrollable.vue'
-import { extensions } from './tiptap-editor'
+import { createExtensions } from './tiptap-editor'
 import { MAX_CHARACTER_COUNT } from '@nodenogg.in/core'
 
 const props = defineProps({
@@ -24,6 +24,9 @@ const props = defineProps({
   editable: {
     type: Boolean,
     default: false
+  },
+  onSplit: {
+    type: Function as PropType<() => void>
   }
 })
 
@@ -34,9 +37,11 @@ const focusActive = ref(false)
 const isInitialized = ref(false)
 const lastEmittedContent = ref(props.value)
 
+const handleSplit = () => props.onSplit?.()
+
 const editor = useEditor({
   editable: props.editable,
-  extensions,
+  extensions: createExtensions({ onSplit: handleSplit }),
   injectCSS: false,
   content: props.value,
   onCreate: () => {

--- a/products/app/src/components/editor/tiptap-editor.ts
+++ b/products/app/src/components/editor/tiptap-editor.ts
@@ -2,6 +2,7 @@ import { StarterKit } from '@tiptap/starter-kit'
 import { Link } from '@tiptap/extension-link'
 import { CharacterCount } from '@tiptap/extension-character-count'
 import { Placeholder } from '@tiptap/extension-placeholder'
+import { Extension, InputRule } from '@tiptap/core'
 import type { Extensions } from '@tiptap/core'
 import { MAX_CHARACTER_COUNT } from '@nodenogg.in/core'
 // import { Document } from '@tiptap/extension-document'
@@ -17,10 +18,26 @@ import { MAX_CHARACTER_COUNT } from '@nodenogg.in/core'
 //   content: 'heading block*'
 // })
 
-export const extensions: Extensions = [
+const SplitNode = Extension.create<{ onSplit?: () => void }>({
+  name: 'splitNode',
+  addInputRules() {
+    return [
+      new InputRule({
+        find: /---$/,
+        handler: ({ commands, range }) => {
+          commands.deleteRange(range)
+          this.options.onSplit?.()
+        }
+      })
+    ]
+  }
+})
+
+export const createExtensions = (options: { onSplit?: () => void } = {}): Extensions => [
   // NodeDocument,
   StarterKit.configure({
     // document: false
+    horizontalRule: false
   }),
   Link.configure({
     HTMLAttributes: {
@@ -40,5 +57,6 @@ export const extensions: Extensions = [
       }
       return ''
     }
-  })
+  }),
+  SplitNode.configure({ onSplit: options.onSplit })
 ]

--- a/products/app/src/components/entity/HTMLEntity.vue
+++ b/products/app/src/components/entity/HTMLEntity.vue
@@ -23,6 +23,7 @@ const props = defineProps<{
   onDelete?: (id: string) => void
   onDuplicate?: (entityOrData: any) => void
   onEmojiCreate?: (emoji: string, entity: EntityOfType<'html'>) => void
+  onSplit?: (entity: EntityOfType<'html'>) => void
   isSelected?: boolean
   editable?: boolean
   isEditing?: boolean
@@ -54,6 +55,9 @@ const handleColorChange = (backgroundColor: string) => {
     props.onUpdate(props.entity.id, { backgroundColor })
   }
 }
+
+// Handler for split (--- shortcut)
+const handleSplit = () => props.onSplit?.(props.entity)
 
 // Handler for when editing is cancelled
 const handleCancel = () => {
@@ -146,7 +150,7 @@ const handleEmojiSelect = (emoji: string) => {
         :on-change="handleContentChange" :on-cancel="handleCancel">
         <!-- Default content if no slot provided -->
         <component v-if="Editor" :is="Editor" :value="entity?.data.content" :onChange="handleContentChange"
-          :editable="isEditing && isEditable" @cancel="handleCancel" />
+          :editable="isEditing && isEditable" :onSplit="handleSplit" @cancel="handleCancel" />
       </slot>
     </div>
 

--- a/products/app/src/constants/copy.ts
+++ b/products/app/src/constants/copy.ts
@@ -15,7 +15,7 @@ export const COPY = {
       actionText: 'Add'
     }
   },
-  
+
   buttons: {
     add: 'Add',
     delete: 'Delete',
@@ -23,7 +23,7 @@ export const COPY = {
     save: 'Save',
     cancel: 'Cancel'
   },
-  
+
   views: {
     collect: {
       title: 'Collect',
@@ -38,21 +38,21 @@ export const COPY = {
       description: 'Organize nodes by tags in columns'
     }
   },
-  
+
   footer: {
     madeBy: 'Made by the University of Southampton, Winchester School of Art'
   },
-  
+
   dialogs: {
     joinMicrocosm: {
-      buttonText: 'Join or Create Microcosm',
-      title: 'Join or Create Microcosm',
-      description: 'Enter a microcosm name and press enter to join or create',
+      buttonText: 'Join a Microcosm',
+      title: 'Join a Microcosm',
+      description: 'Enter a microcosm name and press enter to join',
       placeholder: 'Enter microcosm name...',
       instruction: 'Type a microcosm name to get started',
-      enterToCreate: 'create',
+      enterToCreate: 'join',
       enterToJoin: 'join',
-      keyLabel: 'Enter'
+      keyLabel: 'Enter ↵'
     }
   }
 } as const

--- a/products/app/src/views/collect/CollectNode.vue
+++ b/products/app/src/views/collect/CollectNode.vue
@@ -18,6 +18,7 @@ const props = defineProps<{
     onChange: (update: EntityUpdate) => void
     onDelete: () => void
     onDuplicate: () => void
+    onSplit?: () => void
     entity: Entity
     isEditing: boolean
 }>()
@@ -45,7 +46,7 @@ const { isType } = EntitySchema.utils
     <div class="node" :style="`background-color: ${getColor(entity.data.backgroundColor || 'yellow')}`"
         v-if="isType(entity, 'html')" :class="{ 'is-editing': isEditing }" tabindex="0" :data-entity-id="entity.id">
         <Editor :value="entity.data.content" :onChange="content => onChange({ content })" :editable="isEditing"
-            @click="onStartEditing" @cancel="onStopEditing" />
+            :onSplit="onSplit" @click="onStartEditing" @cancel="onStopEditing" />
 
         <!-- Tag input section -->
         <TagInput :entity="entity" :onUpdate="handleTagUpdate" />

--- a/products/app/src/views/collect/MicrocosmCollectView.vue
+++ b/products/app/src/views/collect/MicrocosmCollectView.vue
@@ -104,6 +104,27 @@ const handleDuplicateEntity = async (e: Entity) => {
   }
 }
 
+const handleSplitEntity = async (entity: Entity) => {
+  if (!EntitySchema.utils.isType(entity, 'html')) return
+
+  const preferredPosition = {
+    x: entity.data.x,
+    y: entity.data.y + (entity.data.height || 200) + 16
+  }
+
+  const dimensions = { width: entity.data.width || 300, height: entity.data.height || 200 }
+  const position = findNonOverlappingPosition(preferredPosition, dimensions, entities.value)
+
+  await create({
+    type: 'html',
+    x: position.x,
+    y: position.y,
+    width: dimensions.width,
+    height: dimensions.height,
+    content: ''
+  })
+}
+
 const handleCreateEmoji = async () => {
   // Use a preferred position around origin with some variance
   const preferredPosition = {
@@ -131,6 +152,7 @@ const handleCreateEmoji = async () => {
     <div class="entities">
       <CollectNode v-for="e in htmlEntities" v-bind:key="`entity/${e.id}`" :entity="e" :onChange="u => update(e.id, u)"
         :onDelete="() => deleteEntity(e)" :isEditing="isEditing(e.id)" :onDuplicate="() => handleDuplicateEntity(e)"
+        :onSplit="() => handleSplitEntity(e)"
         @startEditing="setEditingNode(e.id)" @stopEditing="setEditingNode(null)" />
 
       <EmptyState v-if="htmlEntities.length === 0" :title="COPY.emptyStates.collect.title"

--- a/products/app/src/views/collect/MicrocosmCollectView.vue
+++ b/products/app/src/views/collect/MicrocosmCollectView.vue
@@ -115,7 +115,7 @@ const handleSplitEntity = async (entity: Entity) => {
   const dimensions = { width: entity.data.width || 300, height: entity.data.height || 200 }
   const position = findNonOverlappingPosition(preferredPosition, dimensions, entities.value)
 
-  await create({
+  const newEntity = await create({
     type: 'html',
     x: position.x,
     y: position.y,
@@ -123,6 +123,20 @@ const handleSplitEntity = async (entity: Entity) => {
     height: dimensions.height,
     content: ''
   })
+
+  if (newEntity) {
+    await nextTick()
+    setTimeout(() => {
+      const nodeElement = document.querySelector(`[data-entity-id="${newEntity.id}"]`)
+      if (nodeElement) {
+        nodeElement.scrollIntoView({ behavior: 'smooth', block: 'center' })
+        const editorElement = nodeElement.querySelector('.tiptap') as HTMLElement
+        if (editorElement) {
+          editorElement.focus()
+        }
+      }
+    }, 100)
+  }
 }
 
 const handleCreateEmoji = async () => {

--- a/products/app/src/views/spatial/MicrocosmSpatialView.vue
+++ b/products/app/src/views/spatial/MicrocosmSpatialView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
-import { SpatialView, EmojiEntity } from '@nodenogg.in/spatial-view'
+import { SpatialView, EmojiEntity, useSpatialSelection } from '@nodenogg.in/spatial-view'
 import HTMLEntity from '@/components/entity/HTMLEntity.vue'
 import { useCurrentMicrocosm } from '@/state'
 import { EntitySchema, type Entity } from '@nodenogg.in/schema'
@@ -37,6 +37,7 @@ defineProps({
 // Use the unified entity operations API
 const microcosm = useCurrentMicrocosm()
 const { update, create, deleteEntity } = microcosm
+const { startEditing } = useSpatialSelection()
 
 const { entities } = storeToRefs(microcosm)
 
@@ -360,6 +361,32 @@ const handleDuplicateEntity = async (entityOrData: Entity | Entity['data']) => {
   }
 }
 
+// Handler for split node (--- shortcut) from HTMLEntity
+const handleSplitEntity = async (entity: Entity) => {
+  if (!EntitySchema.utils.isType(entity, 'html')) return
+
+  const preferredPosition = {
+    x: entity.data.x,
+    y: entity.data.y + (entity.data.height || 200) + 16
+  }
+
+  const dimensions = { width: entity.data.width || 200, height: entity.data.height || 200 }
+  const position = findNonOverlappingPosition(preferredPosition, dimensions, entities.value)
+
+  const newEntity = await create({
+    type: 'html',
+    x: position.x,
+    y: position.y,
+    width: dimensions.width,
+    height: dimensions.height,
+    content: ''
+  })
+
+  if (newEntity?.id) {
+    startEditing(newEntity.id)
+  }
+}
+
 // Handler for emoji creation from HTMLEntity dropdown
 const handleEmojiCreateFromEntity = (emoji: string, entity: Entity) => {
   if (EntitySchema.utils.isType(entity, 'html')) {
@@ -397,8 +424,8 @@ const handleEmojiCreateFromEntity = (emoji: string, entity: Entity) => {
   <ViewContainer>
     <div class="spatial-canvas">
       <SpatialView :view_id="view_id" :ui="ui" :nodes="positionedNodes" :HTMLEntity="HTMLEntity" :Editor="Editor"
-        :onUpdate="update" :onDelete="deleteEntity" :onDuplicate="handleDuplicateEntity" :editable="true"
-        :current-user-identity-id="currentIdentity?.id" :zoom-controls="true"
+        :onUpdate="update" :onDelete="deleteEntity" :onDuplicate="handleDuplicateEntity" :onSplit="handleSplitEntity"
+        :editable="true" :current-user-identity-id="currentIdentity?.id" :zoom-controls="true"
         :on-emoji-create="handleEmojiCreateFromEntity" @nodes-change="handleNodeChange">
         <template #node-resizable="resizableNodeProps">
           <!-- HTML entities with resizable handles will now use the app's HTMLEntity -->

--- a/products/app/src/views/spatial/MicrocosmSpatialView.vue
+++ b/products/app/src/views/spatial/MicrocosmSpatialView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, nextTick, ref } from 'vue'
 import { SpatialView, EmojiEntity, useSpatialSelection } from '@nodenogg.in/spatial-view'
 import HTMLEntity from '@/components/entity/HTMLEntity.vue'
 import { useCurrentMicrocosm } from '@/state'
@@ -290,8 +290,7 @@ const handleCreateNode = async () => {
   const nodeDimensions = { width: 200, height: 200 }
   const position = findNonOverlappingPosition(preferredPosition, nodeDimensions, entities.value)
 
-  // Create node at non-overlapping position
-  await create({
+  const newEntity = await create({
     type: 'html',
     x: position.x,
     y: position.y,
@@ -299,6 +298,15 @@ const handleCreateNode = async () => {
     height: nodeDimensions.height,
     content: ''
   })
+
+  if (newEntity?.id) {
+    startEditing(newEntity.id)
+    await nextTick()
+    setTimeout(() => {
+      const editorElement = document.querySelector(`.vue-flow__node[data-id="${newEntity.id}"] .tiptap`) as HTMLElement
+      editorElement?.focus()
+    }, 100)
+  }
 }
 
 // Handler for entity duplication with overlap prevention
@@ -384,6 +392,11 @@ const handleSplitEntity = async (entity: Entity) => {
 
   if (newEntity?.id) {
     startEditing(newEntity.id)
+    await nextTick()
+    setTimeout(() => {
+      const editorElement = document.querySelector(`.vue-flow__node[data-id="${newEntity.id}"] .tiptap`) as HTMLElement
+      editorElement?.focus()
+    }, 100)
   }
 }
 

--- a/products/app/src/views/stack/MicrocosmStackView.vue
+++ b/products/app/src/views/stack/MicrocosmStackView.vue
@@ -185,6 +185,41 @@ const handleCreateEntity = async () => {
   }
 }
 
+const handleSplitEntity = async (entity: Entity) => {
+  if (!EntitySchema.utils.isType(entity, 'html')) return
+
+  const preferredPosition = {
+    x: entity.data.x,
+    y: entity.data.y + (entity.data.height || 200) + 16
+  }
+
+  const dimensions = { width: entity.data.width || 300, height: entity.data.height || 200 }
+  const position = findNonOverlappingPosition(preferredPosition, dimensions, entities.value)
+
+  const newEntity = await create({
+    type: 'html',
+    x: position.x,
+    y: position.y,
+    width: dimensions.width,
+    height: dimensions.height,
+    content: ''
+  })
+
+  if (newEntity) {
+    await nextTick()
+    setTimeout(() => {
+      const nodeElement = document.querySelector(`[data-entity-id="${newEntity.id}"]`)
+      if (nodeElement) {
+        nodeElement.scrollIntoView({ behavior: 'smooth', block: 'center' })
+        const editorElement = nodeElement.querySelector('.tiptap') as HTMLElement
+        if (editorElement) {
+          editorElement.focus()
+        }
+      }
+    }, 100)
+  }
+}
+
 const handleDuplicateEntity = async (e: Entity) => {
   if (EntitySchema.utils.isType(e, 'html')) {
     const htmlData = e.data as Extract<Entity['data'], { type: 'html' }>
@@ -280,6 +315,7 @@ const onPointerUp = () => {
               :onDelete="() => deleteEntity(e)"
               :isEditing="isEditing(e.id)"
               :onDuplicate="() => handleDuplicateEntity(e)"
+              :onSplit="() => handleSplitEntity(e)"
               :onEmojiCreate="(emoji: string) => handleEmojiCreate(emoji, e)"
               :onEmojiDelete="(emojiEntity) => deleteEntity(emojiEntity)"
               :emojis="emojisByParent.get(e.id) || []"

--- a/products/app/src/views/stack/StackNode.vue
+++ b/products/app/src/views/stack/StackNode.vue
@@ -21,6 +21,7 @@ const props = defineProps<{
     onChange: (update: EntityUpdate) => void
     onDelete: () => void
     onDuplicate: () => void
+    onSplit?: () => void
     onEmojiCreate: (emoji: string) => void
     onEmojiDelete: (emoji: EntityOfType<'emoji'>) => void
     entity: Entity
@@ -63,7 +64,7 @@ const { isType } = EntitySchema.utils
         <div class="node" :style="`background-color: ${getColor(entity.data.backgroundColor || 'yellow', isOwner ? 50 : 50)}`"
             :class="{ 'is-editing': isEditing, 'read-only': !isOwner }" tabindex="0" :data-entity-id="entity.id">
             <Editor :value="entity.data.content" :onChange="content => onChange({ content })" :editable="isEditing && isOwner"
-                @click="onStartEditing" @cancel="onStopEditing" />
+                :onSplit="onSplit" @click="onStartEditing" @cancel="onStopEditing" />
 
             <!-- Tag input section - only for owners -->
             <TagInput v-if="isOwner" :entity="entity" :onUpdate="handleTagUpdate" />


### PR DESCRIPTION
Implements a new Tiptap editor extension that allows users to quickly split an HTML node into two by typing `---` (three hyphens) within the editor.

*   **Enhances workflow:** Provides an intuitive keyboard shortcut to create a new, empty HTML node directly below the current one, facilitating rapid content creation and organization.
*   **Automatic Focus:** Ensures a smooth user experience by automatically deleting the `---` input, creating the new node, and then shifting focus to the editor of the newly created node.
*   **Cross-view Integration:** This functionality is integrated into Collect, Spatial, and Stack views.
*   **Focus Management Fixes:** Includes several fixes to improve focus behavior when adding new nodes or splitting existing ones, ensuring the editor is correctly focused for immediate input.
*   **Minor Copy Updates:** Edits some of the 'Join a Microcosm' copy for clarity.